### PR TITLE
added an Eventlistener for undo and redo  keybindings

### DIFF
--- a/canvas_project/static/js/command.mjs
+++ b/canvas_project/static/js/command.mjs
@@ -5,7 +5,7 @@
  * @throws {Error} When the method is not implemented by a subclass.
  */
 
-class Command {
+export class Command {
     /**
      * Initializes a new instance of the Command class.
      * Throws an error if an attempt is made to instantiate the abstract class directly.

--- a/canvas_project/static/js/undoRedoHandler.mjs
+++ b/canvas_project/static/js/undoRedoHandler.mjs
@@ -27,6 +27,7 @@ class UndoRedoHandler {
     constructor() {
         this.#undoStack = [];
         this.#redoStack = [];
+        this.initializeKeyBindings();
     }
 
     /**
@@ -66,11 +67,26 @@ class UndoRedoHandler {
         if (this.#redoStack.length > 0) {
             /** @type {Command} */
             const command = this.#redoStack.pop();
-            command.redo();
+            command.execute();
             this.#undoStack.push(command);
             if (this.#undoStack.length > 100) {
                 this.#undoStack.shift();
             }
         }
+    }
+
+    /**
+     * Initializes key bindings for undo and redo commands.
+     */
+    initializeKeyBindings() {
+        document.addEventListener("keydown", (event) => {
+            if (event.ctrlKey && event.key === "z" && !event.shiftKey) {
+                event.preventDefault();
+                this.undo();
+            } else if (event.ctrlKey && event.shiftKey && event.key === "z") {
+                event.preventDefault();
+                this.redo();
+            }
+        });
     }
 }

--- a/canvas_project/static/js/undoRedoHandler.mjs
+++ b/canvas_project/static/js/undoRedoHandler.mjs
@@ -4,7 +4,7 @@ import { Command } from "command";
  * This class manages the execution of commands and provides undo/redo functionality.
  * It maintains two stacks to keep track of executed and undone commands, allowing users to reverse or reapply actions seamlessly.
  */
-class UndoRedoHandler {
+export class UndoRedoHandler {
     /**
      * A stack that stores commands that have been executed.
      * The stack has a maximum size of 100 commands, and any excess commands will result in the oldest commands
@@ -27,7 +27,7 @@ class UndoRedoHandler {
     constructor() {
         this.#undoStack = [];
         this.#redoStack = [];
-        this.initializeKeyBindings();
+        this.#initializeKeyBindings();
     }
 
     /**
@@ -78,12 +78,20 @@ class UndoRedoHandler {
     /**
      * Initializes key bindings for undo and redo commands.
      */
-    initializeKeyBindings() {
+    #initializeKeyBindings() {
         document.addEventListener("keydown", (event) => {
-            if (event.ctrlKey && event.key === "z" && !event.shiftKey) {
+            if (
+                event.ctrlKey &&
+                event.key.toLowerCase() === "z" &&
+                !event.shiftKey
+            ) {
                 event.preventDefault();
                 this.undo();
-            } else if (event.ctrlKey && event.shiftKey && event.key === "z") {
+            } else if (
+                event.ctrlKey &&
+                event.shiftKey &&
+                event.key.toLowerCase() === "z"
+            ) {
                 event.preventDefault();
                 this.redo();
             }


### PR DESCRIPTION
added an Eventlistener for undo and redo  keybindings and changed a previous mistake: command.redo -> command.execute