### PR TITLE
Reversed button design

### DIFF
--- a/canvas_project/editor/templates/editor/editor.html
+++ b/canvas_project/editor/templates/editor/editor.html
@@ -37,7 +37,7 @@
         import { Editor } from "{% static 'js/editor.mjs' %}";
 
         window.addEventListener('DOMContentLoaded', (_) => {
-            new Editor("{{ project_id }}");
+            new Editor({{ project_id }});
         });
     </script>
 {% endblock %}
@@ -272,10 +272,10 @@
              id="canvas">
             <!--mode selector-->
             <div class="position-absolute mt-4 ms-4 fs-5">
-                <ul class="nav nav-pills flex-column p-2 gap-1 shadow-sm small bg-body-secondary bg-opacity-95 rounded-4 border" id="pillNav2" role="tablist" style="backdrop-filter: blur(0.7rem)"
+                <ul class="nav nav-pills flex-column p-2 gap-1 shadow-sm small bg-body-secondary bg-opacity-75 rounded-4 border" id="pillNav2" role="tablist" style="backdrop-filter: blur(0.7rem)"
                     <li class="nav-item" role="presentation">
                         <button class="nav-link active rounded-3"
-                                id="home-tab2"
+                                id="modeSelect"
                                 data-bs-toggle="tab"
                                 type="button"
                                 role="tab"
@@ -285,7 +285,7 @@
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link rounded-3"
-                                id="profile-tab2"
+                                id="modeMove"
                                 data-bs-toggle="tab"
                                 type="button"
                                 role="tab"
@@ -295,7 +295,7 @@
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link rounded-3"
-                                id="profile-tab2"
+                                id="modeRotate"
                                 data-bs-toggle="tab"
                                 type="button"
                                 role="tab"
@@ -309,22 +309,19 @@
             <div class="position-absolute bottom-0 mb-4 fs-5 d-flex justify-content-center w-100">
                 <div class="p-2 gap-2 shadow-sm bg-body-secondary bg-opacity-75 rounded-4 border d-flex"
                      style="backdrop-filter: blur(0.7rem)">
-                    <button class="btn btn-primary d-flex gap-1 text-reset">
-                        <img src="{% static 'img/Icons/HeliostatIcon.png' %}"
-                             alt="heliostat icon"
-                             style="width: 1.5rem;
-                                    height: fit-content">
+                    <button class="btn btn-primary custom-btn d-flex gap-1 text-reset"
+                            id="quickSettingsHeliostat">
+                        <i class="bi bi-arrow-up-right-square"></i>
                     </button>
-                    <button class="btn btn-primary d-flex gap-1 text-reset">
-                        <img src="{% static 'img/Icons/ReceiverIcon.png' %}"
-                             alt="Receiver icon"
-                             style="width: 1.5rem;
-                                    height: fit-content">
+                    <button class="btn btn-primary custom-btn d-flex gap-1 text-reset"
+                            id="quickSettingsReceiver">
+                        <i class="bi bi-align-bottom"></i>
                     </button>
-                    <button class="btn btn-primary d-flex gap-1 text-reset">
+                    <button class="btn btn-primary custom-btn d-flex gap-1 text-reset"
+                            id="quickSettingsLightsource">
                         <i class="bi bi-lightbulb text-white"></i>
                     </button>
-                    <button class="btn btn-primary rounded-3 fw-bolder bg-blue">Render</button>
+                    <button class="btn btn-primary rounded-3 fw-bolder" id="quickSettingsRender">Render</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Thats because we cant use the custom button icons everywhere as they don't change colors, depending on the mode
(also added id's to all of them for later, and lowered the opacity on the mode selector for glass-morphism, as it was increased) 